### PR TITLE
chore: bump to .NET 8, refresh README, add CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,20 @@
+language: "en"
+early_access: false
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+  path_filters:
+    - "!**/*.min.js"
+    - "!**/bin/**"
+    - "!**/obj/**"
+    - "!**/TestResults/**"
+    - "!**/*.Designer.cs"
+chat:
+  auto_reply: true

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,9 +11,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Run Unit Tests
       run: |

--- a/NosCore.DonationLambda/NosCore.Donation/NosCore.Donation.csproj
+++ b/NosCore.DonationLambda/NosCore.Donation/NosCore.Donation.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
 		<AWSProjectType>Lambda</AWSProjectType>
 	</PropertyGroup>

--- a/NosCore.Shared/NosCore.LambdaShared.csproj
+++ b/NosCore.Shared/NosCore.LambdaShared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NosCore.TravisLambda/NosCore.Travis.Runner/NosCore.Travis.Runner.csproj
+++ b/NosCore.TravisLambda/NosCore.Travis.Runner/NosCore.Travis.Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NosCore.TravisLambda/NosCore.Travis/NosCore.Travis.csproj
+++ b/NosCore.TravisLambda/NosCore.Travis/NosCore.Travis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -1,40 +1,36 @@
+# NosCore Lambdas #
+
 <p align="center">
-  <img src="https://cdn.discordapp.com/attachments/319565884454731795/426892646288457728/N2.png"/>
+  <img width="250px" src="https://github.com/NosCoreIO/NosCore.Packets/blob/15.0.1/icon.png"/>
 </p>
 
-# NosCore Lambdas #
-[![.NET](https://github.com/NosCoreIO/NosCoreLambdas/actions/workflows/dotnet.yml/badge.svg?branch=master)](https://github.com/NosCoreIO/NosCoreLamdas/actions/workflows/dotnet.yml)
+[![.NET](https://github.com/NosCoreIO/NosCoreLambdas/actions/workflows/dotnet.yml/badge.svg?branch=master)](https://github.com/NosCoreIO/NosCoreLambdas/actions/workflows/dotnet.yml)
 
 # Special Thanks for Contributions #
 <p align="left">
-<a href="https://aws.amazon.com"><img height="100px" src="https://chiefit.me/wp-content/uploads/2019/06/Amazon-Web-Services_logo835x396.png"/></a>
-<a href="https://www.navicat.com"><img height="100px" src="https://i.ibb.co/kx9WJgv/Navicat-Premium.png"/></a>
-<a href="https://www.jetbrains.com"><img height="100px" src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1a/JetBrains_Logo_2016.svg/1200px-JetBrains_Logo_2016.svg.png"/></a>
+<a href="https://www.navicat.com"><img height="100px" src="https://user-images.githubusercontent.com/35202750/207230064-dcf23adc-9e96-4481-9a53-cd212f5bd60e.png"/></a>
 </p>
-
 
 ## You want to contribute ? ##
 [![Discord](https://i.gyazo.com/2115a3ecb258220f5b1a8ebd8c50eb8f.png)](https://discord.gg/Eu3ETSw)
 
 ## You like our work ? ##
 <a href='https://github.com/sponsors/0Lucifer0' target='_blank'><img height='48' style='border:0px;height:46px;' src='https://i.gyazo.com/47b2ca2eb6e1ce38d02b04c410e1c82a.png' border='0' alt='Sponsor me!' /></a>
-<a href='https://ko-fi.com/A3562BQV' target='_blank'><img height='46' style='border:0px;height:46px;' src='https://az743702.vo.msecnd.net/cdn/kofi3.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a> <a href='https://www.patreon.com/bePatron?u=6503887' target='_blank'><img height='46' style='border:0px;height:46px;' src='https://c5.patreon.com/external/logo/become_a_patron_button@2x.png' border='0' alt='Become a Patron!' /></a>
+<a href='https://ko-fi.com/A3562BQV' target='_blank'><img height='46' style='border:0px;height:46px;' src='https://az743702.vo.msecnd.net/cdn/kofi3.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
+<a href='https://www.patreon.com/bePatron?u=6503887' target='_blank'><img height='46' style='border:0px;height:46px;' src='https://c5.patreon.com/external/logo/become_a_patron_button@2x.png' border='0' alt='Become a Patron!' /></a>
 
-## Achtung! ##
+## Warning! ##
 We are not responsible of any damages caused by bad usage of our source. Please before asking questions or installing this source read this readme and also do a research, google is your friend. If you mess up when installing our source because you didnt follow it, we will laugh at you. A lot.
 
 ## Instructions to contribute ##
 
 ### Disclaimer ###
-This project not for commercial use.
+This project is a community project not for commercial use. The result is to learn and program together for prove the study.
 
-## Disclaimer ##
-This project is a community project not for commercial use. The result is to learn and program together for prove the study. 
-
-## Legal ##
+### Legal ###
 This is an independent and unofficial server for educational use ONLY. Using the Project might be against the TOS.
 
-### Contribution is only possible with Visual Studio 2017 ###
-We recommend usage of : 
+### Contribution is only possible with Visual Studio 2026 ###
+We recommend usage of :
 * [Roslynator extension](https://github.com/JosefPihrt/Roslynator).
 * [Resharper](https://www.jetbrains.com/resharper/)


### PR DESCRIPTION
## Summary
- Target `net8.0` (was net6.0, which is EOL); AWS Lambda supports .NET 8 LTS
- `setup-dotnet@v4` with `8.0.x`
- README refresh (drop AWS sponsor, Achtung → Warning, GitHub-hosted icon, fix broken workflow badge URL `NosCoreLamdas` → `NosCoreLambdas`)
- Add `.coderabbit.yaml`

Note: .NET 10 was not adopted here because AWS Lambda .NET 10 support is not yet GA — stuck to the LTS Lambda runtime.

## Test plan
- [ ] CI builds cleanly under .NET 8
- [ ] CodeRabbit picks up the new config

🤖 Generated with [Claude Code](https://claude.com/claude-code)