### PR TITLE
chore: bump packages to latest

### DIFF
--- a/NosCore.DonationLambda/NosCore.Donation/NosCore.Donation.csproj
+++ b/NosCore.DonationLambda/NosCore.Donation/NosCore.Donation.csproj
@@ -5,9 +5,9 @@
 		<AWSProjectType>Lambda</AWSProjectType>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="AWSSDK.S3" Version="3.7.101.16" />
-		<PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.2" />
-		<PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
+		<PackageReference Include="AWSSDK.S3" Version="4.0.21.2" />
+		<PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.33" />
+		<PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="9.2.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/NosCore.Shared/NosCore.LambdaShared.csproj
+++ b/NosCore.Shared/NosCore.LambdaShared.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.101.16" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.21.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NosCore.Shared" Version="3.0.0" />
   </ItemGroup>
 

--- a/NosCore.TravisLambda/NosCore.Travis/NosCore.Travis.csproj
+++ b/NosCore.TravisLambda/NosCore.Travis/NosCore.Travis.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.8.1" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.2.5" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bulk package update (AWSSDK/Lambda runtime packages bumped to latest). Supersedes all open Dependabot PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)